### PR TITLE
add ability to bring your own EM project id or name the created project

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,80 @@
+name: 'integration'
+# This workflow intends to verify that the module provisions
+# successfully for all software and infrastructure defined.
+# https://learn.hashicorp.com/tutorials/terraform/automate-terraform
+
+on:
+  push:
+    paths-ignore:
+      - 'LICENSE'
+      - '**.md'
+
+jobs:
+  integrate:
+    name: Integration Tests
+    runs-on: ${{ matrix.os }}
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tf: [0.14.7]
+    env:
+      TF_INPUT: 0
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      TF_IN_AUTOMATION: 1
+      TF_VERSION: ${{ matrix.tf }}
+      TF_VAR_metal_compute-x86_type: "t3.small.x86"
+      TF_VAR_metal_controller_type: "t3.small.x86"
+      TF_VAR_metal_dashboard_type: "t3.small.x86"
+      TF_VAR_metal_create_project: "false"
+      TF_VAR_metal_organization_id: ${{ secrets.METAL_ORGANIZATION_ID }}
+      # TODO only provide this to terraform steps that need it
+      TF_VAR_metal_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
+    steps:
+    - name: Checkout from Github
+      uses: actions/checkout@v2
+    - name: Add SHORT_SHA env property with commit short sha
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ env.TF_VERSION }}
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Initialize Terraform, Modules, and Plugins
+      id: init
+      run: terraform init -input=false
+    - id: project
+      uses: displague/metal-project-action@v0.10.0
+      env:
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
+    # Configure an SSH Agent with a key that can access the project
+    - name: SSH Agent
+      run: |
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add <(echo $METAL_SSH_PRIVATE_KEY_BASE64 | base64 -d)   
+    # Arrays of strings are hard to define via TF env vars (in yaml)
+    - run: |
+        echo 'metal_facilities = ["dfw2"]' > terraform.tfvars
+        echo 'metal_project_id = "${{ steps.project.outputs.projectID }}"' >> terraform.tfvars
+    - name: Terraform Plan
+      id: plan
+      timeout-minutes: 45
+      run: terraform plan -out=tfplan -input=false
+    - name: Terraform Apply
+      id: apply
+      timeout-minutes: 45
+      run: terraform apply -input=false tfplan
+    - name: Terraform Destroy
+      id: destroy
+      if: ${{ always() }}
+      run: terraform destroy -input=false -auto-approve
+    - name: Project Delete
+      if: ${{ always() }}
+      uses: displague/metal-sweeper-action@v0.3.0
+      env:
+        METAL_PROJECT_ID: ${{ steps.project.outputs.projectID }}
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,9 @@ jobs:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       TF_IN_AUTOMATION: 1
       TF_VERSION: ${{ matrix.tf }}
-      TF_VAR_metal_compute-x86_type: "t1.small.x86"
-      TF_VAR_metal_controller_type: "t1.small.x86"
-      TF_VAR_metal_dashboard_type: "t1.small.x86"
+      TF_VAR_metal_compute-x86_type: "c3.small.x86"
+      TF_VAR_metal_controller_type: "c3.small.x86"
+      TF_VAR_metal_dashboard_type: "c3.small.x86"
       TF_VAR_metal_create_project: "false"
       TF_VAR_metal_organization_id: ${{ secrets.METAL_ORGANIZATION_ID }}
       # TODO only provide this to terraform steps that need it

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,9 @@ jobs:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       TF_IN_AUTOMATION: 1
       TF_VERSION: ${{ matrix.tf }}
-      TF_VAR_metal_compute-x86_type: "t3.small.x86"
-      TF_VAR_metal_controller_type: "t3.small.x86"
-      TF_VAR_metal_dashboard_type: "t3.small.x86"
+      TF_VAR_metal_compute-x86_type: "t1.small.x86"
+      TF_VAR_metal_controller_type: "t1.small.x86"
+      TF_VAR_metal_dashboard_type: "t1.small.x86"
       TF_VAR_metal_create_project: "false"
       TF_VAR_metal_organization_id: ${{ secrets.METAL_ORGANIZATION_ID }}
       # TODO only provide this to terraform steps that need it

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,4 +1,7 @@
-name: 'Terraform'
+name: 'terraform'
+# This workflow verifies that the Terraform configs are valid,
+# without running scripts or building any infrastructure.
+# https://learn.hashicorp.com/tutorials/terraform/automate-terraform
 
 on:
   push:
@@ -6,58 +9,31 @@ on:
     - master
   pull_request:
 
-env:
-  TF_INPUT: 0
-  TF_IN_AUTOMATION: 1
-
 jobs:
-  terraform:
-    name: 'Terraform'
-    runs-on: ubuntu-latest
-
-    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-    defaults:
-      run:
-        shell: bash
-
-    # Checkout the repository to the GitHub Actions runner
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    env:
+      TF_IN_AUTOMATION: 1
+      TF_VERSION: ${{ matrix.tf }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tf: [0.14.7]
     steps:
-    - name: Checkout
+    - name: Checkout from Github
       uses: actions/checkout@v2
-
-    # Create the backend configuration used for testing
-    - name: Create testing backend config
-      run: |
-        echo $BACKEND_FILE >> backend.hcl
-      shell: bash
-      env:
-        BACKEND_FILE : ${{secrets.BACKEND_FILE}}
-
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token 
-    - name: Setup Terraform
+    - name: Install Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform init -backend-config=backend.hcl
-
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check
-
-    # Generates an execution plan for Terraform
-    - name: Terraform Plan
-      run: terraform plan
-      env:
-        TF_VAR_metal_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
-
-    # On push to master, build or change infrastructure according to Terraform configuration files
-    # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-    - name: Terraform Apply
-      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: terraform apply -auto-approve
-      env:
-        TF_VAR_metal_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
-
+        terraform_version: ${{ env.TF_VERSION }}
+    - name: Check Terraform formatting
+      id: fmt
+      run: terraform fmt
+      continue-on-error: true
+    - name: Initialize Terraform, Modules, and Plugins
+      id: init
+      run: terraform init -input=false
+    - name: Validate Terraform syntax
+      id: validate
+      run: terraform validate -no-color

--- a/BareMetal.tf
+++ b/BareMetal.tf
@@ -1,3 +1,8 @@
+resource "metal_project" "new_project" {
+  count           = var.metal_create_project ? 1 : 0
+  name            = (var.metal_project_name != "") ? var.metal_project_name : format("openstack-%s", random_id.cloud.b64_url)
+  organization_id = var.metal_organization_id
+}
 
 resource "metal_project" "project" {
   name = format("openstack-%s", random_id.cloud.b64_url)
@@ -8,7 +13,8 @@ provider "metal" {
 }
 
 locals {
-  ssh_key_name = "metal-key"
+  ssh_key_name     = "metal-key"
+  metal_project_id = var.metal_create_project ? metal_project.new_project[0].id : var.metal_project_id
 }
 
 resource "tls_private_key" "ssh_key_pair" {
@@ -47,7 +53,7 @@ resource "metal_device" "controller" {
   }
   user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${local_file.cluster_public_key.content}\""
   facilities    = var.metal_facilities
-  project_id    = metal_project.project.id
+  project_id    = local.metal_project_id
   billing_cycle = "hourly"
   #  ip_address {
   #    type = "public_ipv4"
@@ -70,7 +76,7 @@ resource "metal_device" "dashboard" {
   user_data = "#cloud-config\n\nssh_authorized_keys:\n  - \"${local_file.cluster_public_key.content}\""
 
   facilities    = var.metal_facilities
-  project_id    = metal_project.project.id
+  project_id    = local.metal_project_id
   billing_cycle = "hourly"
 }
 
@@ -90,7 +96,7 @@ resource "metal_device" "compute-x86" {
   }
   user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${local_file.cluster_public_key.content}\""
   facilities    = var.metal_facilities
-  project_id    = metal_project.project.id
+  project_id    = local.metal_project_id
   billing_cycle = "hourly"
 }
 
@@ -110,7 +116,7 @@ resource "metal_device" "compute-arm" {
   }
   user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${local_file.cluster_public_key.content}\""
   facilities    = var.metal_facilities
-  project_id    = metal_project.project.id
+  project_id    = local.metal_project_id
   billing_cycle = "hourly"
 }
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,20 @@ By default, upstream connectivity from inside the cloud (virtual machines/networ
 
 ### Equinix Metal Project ID & API Key
 
-This deployment requires a Equinix Metal account for the provisioned bare metal. You'll need your "Equinix Metal Project ID" and your "Equinix Metal API Key" to proceed. You can use an existing project or create a new project for the deployment.
+This deployment requires a Equinix Metal account for the provisioned bare metal. You'll need your "Equinix Metal Organization ID" and your "Equinix Metal API Key" to proceed. You can use an existing project or create a new project for the deployment. [See the full list of inputs](https://registry.terraform.io/modules/equinix/openstack/metal/latest?tab=inputs) for details.
 
-We recommend setting the Equinix Metal API Token and Project ID as environment variables since this prevents tokens from being included in source code files. These values can also be stored within a variables file later if using environment variables isn't desired.
+In this walk-through, we will let Terraform create a randomly named project in the organization that you define.
+
+We recommend setting the Equinix Metal API Token and Organization ID as environment variables since this prevents tokens from being included in source code files. These values can also be stored within a variables file later if using environment variables isn't desired.
 
 ```bash
-export TF_VAR_metal_project_id=YOUR_PROJECT_ID_HERE
+export TF_VAR_metal_organization_id=YOUR_ORGANIZATION_ID_HERE
 export TF_VAR_metal_auth_token=YOUR_PACKET_TOKEN_HERE
 ```
+
+#### Where is my Equinix Metal Organization ID?
+
+You can find your Organization ID in the organization settings. Click "Settings" in the "Hello, ..." profile menu. Make sure you copy the Organization ID, not the Account ID.
 
 #### Where is my Equinix Metal Project ID?
 
@@ -52,7 +58,7 @@ You can find your Project ID under the 'Manage' section in the Equinix Metal Por
 
 You will find your API Key on the left side of the portal. If you have existing keys you will find them listed on that page. If you haven't created one yet, you can click here:
 
-https://console.equinix.com/#/api-keys/new
+<https://console.equinix.com/#/api-keys/new>
 
 #### Ensure that your Equinix Metal account has an SSh key attached
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,30 @@ variable "metal_facilities" {
   default     = ["sjc1"]
 }
 
+variable "metal_project_id" {
+  type        = string
+  default     = "null"
+  description = "Equinix Metal Project ID"
+}
+
+variable "metal_organization_id" {
+  type        = string
+  default     = "null"
+  description = "Equinix Metal Organization ID"
+}
+
+variable "metal_create_project" {
+  type        = bool
+  default     = true
+  description = "Create a Metal Project if this is 'true'. Else use provided 'metal_project_id'"
+}
+
+variable "metal_project_name" {
+  type        = string
+  default     = "baremetal-anthos"
+  description = "The name of the Metal project if 'create_project' is 'true'."
+}
+
 variable "metal_controller_type" {
   description = "Instance type of OpenStack controller"
   default     = "c3.medium.x86"


### PR DESCRIPTION
Adds the ability to bring your own Equinix Metal Project ID.

* Organization ID is now required, If creating a project. The project name can now be specified or use the existing randomly generated name.
* Project ID can now be specified. When specified, set `metal_create_project` to `false`.

* Fixes the integration test by defining the needed GitHub secrets
* Makes the test ephemeral. Hashicorp's external state is no longer used, a project creation and sweeping action is used.

Fixes #54 (not sure how, but the tests should help confirm)
Fixes #50 
