### PR TITLE
default project name should be unique

### DIFF
--- a/sample-arm.terraform.tfvars
+++ b/sample-arm.terraform.tfvars
@@ -12,3 +12,11 @@ openstack_compute-arm_count = 1
 openstack_compute-x86_count = 0
 
 metal_facilities = ["ewr1"]
+
+# Use an existing project:
+# metal_create_project        = false
+# metal_project_id           = "..."
+#
+# Or create a new one (default), requiring organization_id :
+# metal_create_project        = true
+# metal_organization_id       = "..."

--- a/sample-gen3.terraform.tfvars
+++ b/sample-gen3.terraform.tfvars
@@ -12,3 +12,11 @@ openstack_compute-arm_count = 1
 openstack_compute-x86_count = 1
 
 metal_facilities = ["dfw2"]
+
+# Use an existing project:
+# metal_create_project        = false
+# metal_project_id           = "..."
+#
+# Or create a new one (default), requiring organization_id :
+# metal_create_project        = true
+# metal_organization_id       = "..."

--- a/sample.terraform.tfvars
+++ b/sample.terraform.tfvars
@@ -15,3 +15,11 @@ openstack_compute-arm_count = 1
 openstack_compute-x86_count = 1
 
 metal_facilities = ["sjc1"]
+
+# Use an existing project:
+# metal_create_project        = false
+# metal_project_id           = "..."
+#
+# Or create a new one (default), requiring organization_id :
+# metal_create_project        = true
+# metal_organization_id       = "..."

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "metal_create_project" {
 
 variable "metal_project_name" {
   type        = string
-  default     = "baremetal-anthos"
+  default     = "terraform-metal-openstack"
   description = "The name of the Metal project if 'create_project' is 'true'."
 }
 


### PR DESCRIPTION
The default project name is currently "baremetal-anthos".

The first commit in this PR changes that to something more accurate.

The goal is to make this a prefix variable so that the generated project names will be unique.  We can see examples of this on terraform-metal-vsphere.

This PR should attempt to cover #58 too.